### PR TITLE
Development environment setup: Fix Docker build and Composer 2 compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -480,3 +480,40 @@ Located in `src/Domain/Exception/`:
 - Exceptions: 4 (ValidationException, InvalidTaskException, TaskNotFoundException, CouldNotDeleteException)
 - Kernel: 1 (Kernel.php)
 - Migrations: 1 (Version20200308095622.php)
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+
+This is a Symfony 5.0 REST API (PHP 7.4) with Docker-based services (MySQL 5.7, PHP-FPM, Nginx). Tests use SQLite in-memory and do not require Docker.
+
+### Running tests (no Docker needed)
+
+```bash
+cd /workspace && vendor/bin/simple-phpunit
+```
+
+Tests use SQLite via `config/packages/test/doctrine.yaml`, so MySQL is not required.
+
+### Running lint
+
+```bash
+vendor/bin/phpcs --standard=phpcs.xml.dist src/
+```
+
+### Running the application (Docker)
+
+```bash
+sudo docker compose up -d
+sudo docker compose exec php-fpm php bin/console doctrine:schema:update --force
+```
+
+The API is then available at `http://localhost:8101/api/task`. Swagger UI at `http://localhost:8101/api/doc`.
+
+### Gotchas
+
+- The `composer.lock` was generated with Composer 1. Use `composer config --no-plugins allow-plugins.ocramius/package-versions true` and `composer config --no-plugins allow-plugins.symfony/flex true` before `composer install` on Composer 2.
+- The `docker/build/Dockerfile` uses `--ignore-platform-reqs --no-scripts` because the `composer` Docker image ships PHP 8.x+ while the project targets PHP 7.4. The runtime `php-fpm` container uses PHP 7.4.
+- `doctrine:migrations:migrate` may fail due to a Doctrine Migrations version incompatibility (`Undefined class constant 'VERSIONS'`). Use `doctrine:schema:update --force` instead for initial DB setup.
+- No `bin/phpunit` exists; use `vendor/bin/simple-phpunit` which bootstraps PHPUnit 7.5 via the Symfony PHPUnit Bridge.
+- Code coverage requires Xdebug; the "No code coverage driver is available" warning is harmless for running tests.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,11 @@
         "preferred-install": {
             "*": "dist"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "ocramius/package-versions": true,
+            "symfony/flex": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1392,34 +1392,36 @@
         },
         {
             "name": "ocramius/package-versions",
-            "version": "1.4.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d"
+                "reference": "f51ff2b2b49baaa302d6bf71880e4d8b5acd7015"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
-                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/f51ff2b2b49baaa302d6bf71880e4d8b5acd7015",
+                "reference": "f51ff2b2b49baaa302d6bf71880e4d8b5acd7015",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0.0",
-                "php": "^7.1.0"
+                "composer-plugin-api": "^2.0.0",
+                "composer-runtime-api": "^2.0.0",
+                "php": "^7.4.7"
             },
             "require-dev": {
-                "composer/composer": "^1.6.3",
-                "doctrine/coding-standard": "^5.0.1",
-                "ext-zip": "*",
-                "infection/infection": "^0.7.1",
-                "phpunit/phpunit": "^7.5.17"
+                "composer/composer": "^2.0.0@dev",
+                "doctrine/coding-standard": "^8.1.0",
+                "ext-zip": "^1.15.0",
+                "infection/infection": "^0.16.4",
+                "phpunit/phpunit": "^9.1.5",
+                "vimeo/psalm": "^3.12.2"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "PackageVersions\\Installer",
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.99.x-dev"
                 }
             },
             "autoload": {
@@ -1438,7 +1440,21 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-11-15T16:17:10+00:00"
+            "support": {
+                "issues": "https://github.com/Ocramius/PackageVersions/issues",
+                "source": "https://github.com/Ocramius/PackageVersions/tree/1.11.x"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ocramius/package-versions",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-21T12:16:47+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -2994,33 +3010,34 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.6.2",
+            "version": "v1.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "e4f5a2653ca503782a31486198bd1dd1c9a47f83"
+                "reference": "5cc985971b1a700cb74bedd9e01cfa93eb4747f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/e4f5a2653ca503782a31486198bd1dd1c9a47f83",
-                "reference": "e4f5a2653ca503782a31486198bd1dd1c9a47f83",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/5cc985971b1a700cb74bedd9e01cfa93eb4747f7",
+                "reference": "5cc985971b1a700cb74bedd9e01cfa93eb4747f7",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^7.0"
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": ">=7.1"
+            },
+            "conflict": {
+                "composer/semver": "<1.7.2"
             },
             "require-dev": {
-                "composer/composer": "^1.0.2",
-                "symfony/dotenv": "^3.4|^4.0|^5.0",
-                "symfony/phpunit-bridge": "^3.4.19|^4.1.8|^5.0",
-                "symfony/process": "^2.7|^3.0|^4.0|^5.0"
+                "composer/composer": "^1.0.2|^2.0",
+                "symfony/dotenv": "^4.4|^5.0|^6.0",
+                "symfony/filesystem": "^4.4|^5.0|^6.0",
+                "symfony/phpunit-bridge": "^4.4.12|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
-                },
                 "class": "Symfony\\Flex\\Flex"
             },
             "autoload": {
@@ -3039,7 +3056,25 @@
                 }
             ],
             "description": "Composer plugin for Symfony",
-            "time": "2020-01-30T12:06:45+00:00"
+            "support": {
+                "issues": "https://github.com/symfony/flex/issues",
+                "source": "https://github.com/symfony/flex/tree/v1.22.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-03T07:50:24+00:00"
         },
         {
             "name": "symfony/framework-bundle",
@@ -5094,7 +5129,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -5102,5 +5137,6 @@
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": []
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -2,4 +2,4 @@ FROM composer as builder
 WORKDIR /var/www/task-list
 COPY ./ /var/www/task-list
 
-RUN composer install
+RUN composer install --ignore-platform-reqs --no-interaction --no-scripts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Symfony 5.0 Task Management REST API by fixing Docker build and Composer 2 compatibility issues.

### Changes

* **`docker/build/Dockerfile`**: Added `--ignore-platform-reqs --no-scripts` flags to `composer install` since the `composer` Docker image now ships PHP 8.x+ while the project targets PHP 7.4
* **`composer.json` / `composer.lock`**: Updated for Composer 2 compatibility by configuring `allow-plugins` for `ocramius/package-versions` and `symfony/flex`
* **`AGENTS.md`**: Added Cursor Cloud specific instructions section with environment setup gotchas for future agents

### Environment Verification

All key development tasks verified working:

| Check | Command | Status |
|-------|---------|--------|
| Lint | `vendor/bin/phpcs --standard=phpcs.xml.dist src/` | Pass (warnings only in migrations) |
| Tests | `vendor/bin/simple-phpunit` | Pass (36 tests, 133 assertions) |
| Docker Build | `sudo docker compose build` | Pass |
| Docker Run | `sudo docker compose up -d` | Pass (MySQL, PHP-FPM, Nginx) |
| API: Create Task | `POST /api/task` | Pass |
| API: List Tasks | `GET /api/task` | Pass |
| API: Get Task | `GET /api/task/{id}` | Pass |
| API: Complete Task | `PUT /api/task/{id}/complete` | Pass |
| API: Swagger UI | `GET /api/doc` | Pass (HTTP 200) |

### Hello World Demo

API test log showing full CRUD lifecycle:

[api_hello_world_test.log](https://cursor.com/agents/bc-46c2d2c5-3152-4edd-9610-61c228b76823/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_hello_world_test.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46c2d2c5-3152-4edd-9610-61c228b76823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46c2d2c5-3152-4edd-9610-61c228b76823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

